### PR TITLE
Fix typos and apply C4LJ style for citations

### DIFF
--- a/elxn42.md
+++ b/elxn42.md
@@ -4,13 +4,13 @@ Nick Ruest (York University), Ian Milligan (University of Waterloo)
 
 ## Abstract
 
-This article examines the tools, approaches, collaboration, and findings of the Web Archives for Historical Research Group around the capture and analysis of about 4M tweets during the 2015 Canadian Federal Election. We hope that national libraries and other heritage institutions will find our model useful as they consider how to capture, preserve, and analyze ongoing events using Twitter.
+This article examines the tools, approaches, collaboration, and findings of the Web Archives for Historical Research Group around the capture and analysis of about 4 million tweets during the 2015 Canadian Federal Election. We hope that national libraries and other heritage institutions will find our model useful as they consider how to capture, preserve, and analyze ongoing events using Twitter.
 
 While Twitter is not a representative sample of broader society - Pew Research notes that it skews young, college-educated, and affluent (above $50,000 household income) – Twitter still represents an exponential increase in the amount of information generated, retained, and preserved from 'everyday' people. Therefore, when historians study the 2015 federal election, Twitter will be a prime source.
 
-On August 3, 2015, the team initiated both a Search API and Stream API collection with twarc, a tool developed by Ed Summers, using the hashtag #elxn42. The hashtag refered to the election being Canada's 42nd general federal election (hence 'election 42' or elxn42). Data collection ceased on November 5, 2015, the day after Justin Trudeau was sworn in as the 42nd Prime Minister of Canada. We collected for a total of 102 days, 13 hours and 50 minutes.
+On August 3, 2015, the team initiated both a Search API and Stream API collection with [twarc](https://github.com/edsu/twarc), a tool developed by Ed Summers, using the hashtag #elxn42. The hashtag refered to the election being Canada's 42nd general federal election (hence 'election 42' or elxn42). Data collection ceased on November 5, 2015, the day after Justin Trudeau was sworn in as the 42nd Prime Minister of Canada. We collected for a total of 102 days, 13 hours and 50 minutes.
 
-To analyze the data set, we took advantage of a number of command line tools, utilities that are available within twarc, twarc-report, and `jq`. In accordance with the [Twitter Developer Agreement & Policy](https://dev.twitter.com/overview/terms/agreement-and-policy), and after ethical deliberations discussed below, we made the tweet IDs and other derivative data available in a data repository. This allows other people to use our dataset, cite our dataset, and enhance their own research projects by drawing on #elxn42 tweets.
+To analyze the data set, we took advantage of a number of command line tools, utilities that are available within twarc, [twarc-report](https://github.com/pbinkley/twarc-report), and [`jq`](https://stedolan.github.io/jq/). In accordance with the [Twitter Developer Agreement & Policy](https://dev.twitter.com/overview/terms/agreement-and-policy), and after ethical deliberations discussed below, we made the tweet IDs and other derivative data available in a data repository. This allows other people to use our dataset, cite our dataset, and enhance their own research projects by drawing on #elxn42 tweets.
 
 Our analytics included:
 
@@ -23,7 +23,7 @@ Our article introduces our collecting work, ethical considerations, the analysis
 
 ## Introduction
 
-During the 2015 Canadian federal elections, we captured 3,918,932 tweets written using the #elxn42 hashtag: thoughts on the nature and stature of political candidates or parties, live running commentary during leader debates, exhortations to vote, witty ripostes or jokes to liven up the long campaign. Political scientists, journalists, and other researchers can use these tweets as evidence of sentiment amongst a certain slice of the electorate: did a policy go over well? Did it not? What tweets get re-tweeted, or further shared, and which ones do not? If these are questions that resonate amongst contemporary researchers, historians are also interested in the long-term preservation of digital material. Tweets, as well as the much broader scope of archived webpages and born-digital data, are the primary sources of tomorrow. Websites and tweets present considerable advantages in that they represent the preservation of material representing the voices of everyday people that might not otherwise be saved, but also considerable challenges in the collection and use of data on such a large scale. If the norm until the digital era was to have human information vanish, "now expectations have inverted. Everything may be recorded and preserved, at least potentially" (James Gleick, _The Information: A History, a Theory, a Flood_, 2012). Useful historical information is being preserved at mind-boggling rates that continue to accelerate. IBM Research, for example, notes that "every day, we create 2.5 quintillion bytes of data --- so much that 90% of the data in the world today has been created in the last two years alone."
+During the 2015 Canadian federal elections, we captured 3,918,932 tweets written using the #elxn42 hashtag: thoughts on the nature and stature of political candidates or parties, live running commentary during leader debates, exhortations to vote, and witty ripostes or jokes to liven up the long campaign. Political scientists, journalists, and other researchers can use these tweets as evidence of sentiment amongst a certain slice of the electorate: did a policy go over well? Did it not? What tweets get re-tweeted, or further shared, and which ones do not? If these are questions that resonate amongst contemporary researchers, historians are also interested in the long-term preservation of digital material. Tweets, as well as the much broader scope of archived webpages and born-digital data, are the primary sources of tomorrow. Websites and tweets present considerable advantages in that they represent the preservation of material representing the voices of everyday people that might not otherwise be saved, but also considerable challenges in the collection and use of data on such a large scale. If the norm until the digital era was to have human information vanish, "now expectations have inverted. Everything may be recorded and preserved, at least potentially" (Gleick, 2012). Useful historical information is being preserved at mind-boggling rates that continue to accelerate. IBM Research, for example, notes that "every day, we create 2.5 quintillion bytes of data --- so much that 90% of the data in the world today has been created in the last two years alone." (Ainsworth, 2012)
 
 This data has the potential to reshape multiple avenues of historical research. In the case of the #elxn42 hashtag, we have access to the tweets of some 318,176 unique users (which would include some bots and spam accounts, of course). Consider what the scale of this dataset means. Social and cultural historians will have access to the thoughts, behaviours, and activities of everyday people, the sorts of which who are not generally preserved in the record. Military historians will have access to the voices of soldiers, posting from overseas missions and their bases at home. And political historians will have a significant opportunity to see how people engaged with politicians and the political sphere, during both elections and between them. The scale boggles. Modern social movements, from the Canadian #IdleNoMore protest focusing on the situation of First Nations peoples to the global #Occupy movement that grew out of New York City, leave the sorts of records that would rarely, if ever, have been kept by previous generations. During the #IdleNoMore protest, for example, twitter witnessed an astounding 55,334 tweets on 11 January 2013. If we were to take the median length of a tweet (60 characters), the average length of a word (5 characters plus a space), and think about 300 words per page, we're looking at over 1,800 pages. This for a single day of a single social movement in the relatively small country of Canada.
 
@@ -43,7 +43,7 @@ This article walks users through these five steps, with an eye to presenting thi
 
 ## Creating your Own Twitter Archive: Data Collection
 
-The [Web Archives for Historical Research Group](https://uwaterloo.ca/web-archive-group/) began capturing #elxn42 tweets on August 3, 2015 with [twarc](https://github.com/edsu/twarc). "twarc is a command line tool and Python library for archiving Twitter JSON data. Each tweet is represented as a JSON object that is exactly what was returned from the Twitter API. Tweets are stored as line-oriented JSON. It twarc runs in three modes: search, stream and hydrate. When running in each mode twarc will stop and resume activity in order to work within the Twitter API's rate limits."[1]
+The [Web Archives for Historical Research Group](https://uwaterloo.ca/web-archive-group/) began capturing #elxn42 tweets on August 3, 2015 with [twarc](https://github.com/edsu/twarc). "twarc is a command line tool and Python library for archiving Twitter JSON data. Each tweet is represented as a JSON object that is exactly what was returned from the Twitter API. Tweets are stored as line-oriented JSON. It twarc runs in three modes: search, stream and hydrate. When running in each mode twarc will stop and resume activity in order to work within the Twitter API's rate limits." (Summers, _et al_, 2015)
 
 On August 3, the team initiated both a search API and stream API collection with twarc using the hashtag #elxn42. The search API was used to gather any tweets with the #elxn42 hashtag before initial collection date. The stream collection mode was initiated with the intention to gather #elxn42 tweet for the entirety of the election. However, we noticed that twarc had silently failed during September, and the research team did not notice. We believe the failure here was because of an issue with the Twitter API or network connection issues, but it is not clear, and we are not confident as to why we had a silent failure. As a result we lost 27 days in total. Upon realization of the collection failure, the research team immediately began collecting via the stream API and began search API collection (allows collection back 7-9 days) simultaneously. Data Collection was stopped on November 5, 2015, the day after Justin Trudeau was sworn in as the 42nd Prime Minister of Canada. A total of 102 days, 13hrs and 50 minutes.
 
@@ -51,7 +51,7 @@ On August 3, the team initiated both a search API and stream API collection with
 
 In retrospect, the research team recommends using a combination of collection via the search and streaming API. A streaming API collection over the period of the capture, as well weekly search API collections. Then, at the end of data collection concatenating all files together, and deduplicating the entire dataset.
 
-Library and Archives Canada (LAC) also collected the #elxn42 hashtag, using the Search API, during a similar time period; August 11, 2015 - October 28, 2015. The team made use of the LAC #elxn42 capture by downloading their tweet id dataset[7], and hydrating it. Once the LAC dataset was hydrated, the team combined their original dataset[4] with the LAC dataset[7], and deduplicated it[6].
+Library and Archives Canada (LAC) also collected the #elxn42 hashtag, using the Search API, during a similar time period; August 11, 2015 - October 28, 2015. The team made use of the LAC #elxn42 capture by downloading [their tweet id dataset](http://hdl.handle.net/10864/11310), and hydrating it. Once the LAC dataset was hydrated, the team combined their [original dataset](http://hdl.handle.net/10864/11270) with the LAC dataset, and [deduplicated it](http://hdl.handle.net/10864/11311).
 
 ```bash
 $ twarc.py --hydrate elxn42-tweets-LAC.txt > elxn42-tweets-LAC.json
@@ -61,7 +61,7 @@ $ python ~/git/twarc/utils/deduplicate.py elxn42-tweets-combined.json > elxn42-t
 
 ![tweet times](tweet-times.png)
 
-This does not necessarily mean that between LAC and our research group that we captured all tweets. Driscoll and Walker have shown substantial differences in what is captured using Twitter's commercial Gnip service versus the streaming API.[9] While the #elxn42 hashtag never exceeded the hard limit of 1% of all tweets enacted using the streaming API – which comes into play if the volume of tweets you are capturing exceeds 1%, common in cases such as high-profile events (the Paris shootings or an American presidential debate) - there is still a chance that some content was not collected.
+This does not necessarily mean that between LAC and our research group that we captured all tweets. Driscoll and Walker (2014) have shown substantial differences in what is captured using Twitter's commercial Gnip service versus the streaming API. While the #elxn42 hashtag never exceeded the hard limit of 1% of all tweets enacted using the streaming API – which comes into play if the volume of tweets you are capturing exceeds 1%, common in cases such as high-profile events (the Paris shootings or an American presidential debate) - there is still a chance that some content was not collected.
 
 ### How Do You Collect?
 
@@ -73,13 +73,13 @@ Stream API ( < v0.5.0 twarc): `twarc.py --stream "#elxn42" > elxn42-stream.json`
 
 Stream API ( > v0.5.0 twarc): `twarc.py --track "#elxn42" > elxn42-stream.json`
 
-These two APIs complement each other well. The Search API provides historical search on a given query, such as #elxn42, stretching back somewhere between six and nine days of Tweets. Their API cautions that "the Search API is focused on relevance and not completeness. This means that some Tweets and users may be missing from search results."[10] Given our project goals, the Search API is insufficient.
+These two APIs complement each other well. The [Search API](https://dev.twitter.com/rest/public/search) provides historical search on a given query, such as #elxn42, stretching back somewhere between six and nine days of Tweets. Their API cautions that "the Search API is focused on relevance and not completeness. This means that some Tweets and users may be missing from search results." Given our project goals, the Search API is insufficient.
 
-For completeness, then, we can turn to the Streaming API. This gives "developers low latency access to Twitter's global stream of Tweet data," up to the aforementioned 1% volume.[11] Whereas Search API goes back into past tweets, Streaming only captures tweets _as they happen_. To put this into context, we could begin the Search API on #elxn42 on 5 September 2015 and still get tweets from 3 September 2015, for example; Streaming API cannot retroactively gather content. It is more complete, however.
+For completeness, then, we can turn to the [Streaming API](https://dev.twitter.com/streaming/overview). This gives "developers low latency access to Twitter's global stream of Tweet data," up to the aforementioned 1% volume. Whereas Search API goes back into past tweets, Streaming only captures tweets _as they happen_. To put this into context, we could begin the Search API on #elxn42 on 5 September 2015 and still get tweets from 3 September 2015, for example; Streaming API cannot retroactively gather content. It is more complete, however.
 
 A combination of the two is a recommended approach: the streaming API for the bulk collection, and the search API to fill in any gaps that may have happened when using the system.
 
-Once collected, tweets can be shared with other people through the tweet IDs, which can be rehydrated using twarc. As twarc's README notes:
+Once collected, tweets can be shared with other people through the tweet IDs, which can be rehydrated using twarc. As [twarc's README](https://github.com/edsu/twarc/blob/master/README.md) notes:
 
 >The Twitter API's Terms of Service prevent people from making large amounts of raw Twitter data available on the Web. The data can be used for research and archived for local use, but not shared with the world. Twitter does allow files of tweet identifiers to be shared, which can be useful when you would like to make a dataset of tweets available. You can then use Twitter's API to hydrate the data, or to retrieve the full JSON for each identifier. This is particularly important for verification of social media research.
 
@@ -93,21 +93,21 @@ will recreate the original tweet(s) in json format, provided the content is stil
 
 Beyond the technical question of how to collect tweets comes the ever-important question of should you, and if so, how to handle the question of consent? Strictly speaking, we have permission in accordance in a "legal sense," thanks to the [Twitter Developer Agreement & Policy](https://dev.twitter.com/overview/terms/agreement-and-policy). We can only capture public tweets, and given the tweets are public, we interpret that as consent in the broadest form to archive and preserve this material. Consent is not perpetual, as users may decide to make their account "private" after collection. Accordingly, when tweet ids are hydrated, only publicly accessible tweets are hydrated (indeed, as deleted or private tweets are not made available via the API, this is unavoidable - one cannot get data about a deleted tweet from Twitter).
 
-So, if a tweet is deleted in the period between our capture and hydration, the tweet will not be hydrated. Similarly, if an account is public, and set to private in the period between our capture and hydration, the tweet will not be hydrated. We discusss this futher in our sectiono below on deleted tweets.
+So, if a tweet is deleted in the period between our capture and hydration, the tweet will not be hydrated. Similarly, if an account is public, and set to private in the period between our capture and hydration, the tweet will not be hydrated. We discuss this further in our section below on deleted tweets.
 
-George Washington University's Library has been exploring, as part of their work with the [Social Feed Manager](https://social-feed-manager.readthedocs.org/en/m5_004/) – a platform to collect social media data from Twitter – the legal and ethical implications of Twitter archiving. In a recent presentation at *Web Archives 2015: Capture, Curate, Analyze*, Seemantani Sharma, Vakil Smallen, and Daniel Chudnov explored the three primary legal areas of concern: copyright, privacy, and access. While in the United States, fair dealing largely would not see tweets as copyrighted content, they accordingly focus much of their attention on the murkier area of the ethical concerns of privacy and access.[15] Securing consent at the collection stage is largely unworkable (can you imagine getting a tweet asking you to preserve content - we are both web archivists and we would fear spam), as Sharma, Smallen, and Chudnov note - making this a far trickier question.
+George Washington University's Library has been exploring, as part of their work with the [Social Feed Manager](https://social-feed-manager.readthedocs.org/en/m5_004/) – a platform to collect social media data from Twitter – the legal and ethical implications of Twitter archiving. In a recent presentation at *Web Archives 2015: Capture, Curate, Analyze*, Seemantani Sharma, Vakil Smallen, and Daniel Chudnov (2015) explored the three primary legal areas of concern: copyright, privacy, and access. While in the United States, fair dealing largely would not see tweets as copyrighted content, they accordingly focus much of their attention on the murkier area of the ethical concerns of privacy and access. Securing consent at the collection stage is largely unworkable (can you imagine getting a tweet asking you to preserve content - we are both web archivists and we would fear spam), as Sharma, Smallen, and Chudnov note - making this a far trickier question.
 
-As they note, and as we know, legal does not equal ethical, though. As Aaron Bady has noted, "[t]he act of linking or quoting someone who does not regard their twitter as public is only ethically fine if we regard the law as trumping the ethics of consent."[12] As researchers at the University of Southern California discovered with their "Black Twitter Project," many are uncomfortable with the prospect of their online content being harnessed without consent for research projects.[13]
+As they note, and as we know, legal does not equal ethical, though. As Aaron Bady (2014) has noted, "[t]he act of linking or quoting someone who does not regard their twitter as public is only ethically fine if we regard the law as trumping the ethics of consent." As researchers at the University of Southern California discovered with their "Black Twitter Project," many are uncomfortable with the prospect of their online content being harnessed without consent for research projects. (O'Neil, 2014)
 
-Yet, if we do not archive this material, it could be lost forever: invaluable, diverse perspectives on unfolding events like the 2015 Canadian federal election. Collecting these tweets raises the prospect of histories not dominated by the mainstream media. We thus collect the material with the proviso that it needs to be ethically used by researchers. As Dorothy Kim and Eunsong Kim put it in their "#TwitterEthics Manifesto," academics and those using this material in their work need to rethink their approach:
+Yet, if we do not archive this material, it could be lost forever: invaluable, diverse perspectives on unfolding events like the 2015 Canadian federal election. Collecting these tweets raises the prospect of histories not dominated by the mainstream media. We thus collect the material with the proviso that it needs to be ethically used by researchers. As Dorothy Kim and Eunsong Kim (2014) put it in their "#TwitterEthics Manifesto," academics and those using this material in their work need to rethink their approach:
 
->In the end, the work, the credit, the compensation, and the view need to be a shared, collaborative process. Twitter and New Media journalism, the internet and technology involves all of us. The voices on the platform are multiple, collective, dissenting, singular, and loud. You don’t need to speak for us–we are talking. Cite us, ask us to write, get our permission.[14]
+>In the end, the work, the credit, the compensation, and the view need to be a shared, collaborative process. Twitter and New Media journalism, the internet and technology involves all of us. The voices on the platform are multiple, collective, dissenting, singular, and loud. You don’t need to speak for us–we are talking. Cite us, ask us to write, get our permission.
 
 We collect the material so that it can be used. Researchers need to be ethically aware. When distributing the Tweet IDs, we encourage them to use this material with respect.
 
 ## Approach to Analysis
 
-To analyze the data set, we took advantage of a command line utilities, a number of utilities that are available with twarc and [twarc-report](https://github.com/pbinkley/twarc-report), as well as [jq](https://stedolan.github.io/jq/). twarc-report is a set of utilities "for generating reports from twarc collections using tools such as D3.js."[2] The timeline graphs above were created with twarc-report. The command is as follows:
+To analyze the data set, we took advantage of a command line utilities, a number of utilities that are available with twarc and [twarc-report](https://github.com/pbinkley/twarc-report), as well as [jq](https://stedolan.github.io/jq/). twarc-report is a set of utilities "for generating reports from twarc collections using tools such as D3.js." The timeline graphs above were created with twarc-report. The command is as follows:
 
 `python ~/git/twarc-report/d3times.py elxn42-tweets-combined-deduplicated.json -a -o embed -t local -i 24H > elxn42-times.html`
 
@@ -120,7 +120,7 @@ $ cat elxn42-tweets-combined-deduplicated.json | wc -l
 3918932
 ```
 
-Since Twitter automatically shortens URLs, the team also unshortened every URL in the dataset so that we would be able create a canonical list of URLs tweeted for further analysis. We were able to create this using a combination of tools; [`unshorten.py`](https://github.com/edsu/twarc/blob/master/utils/unshorten.py) and [unshrtn](https://github.com/edsu/unshrtn) ("a small leveldb backed URL unshortening microservice written for node")[3].
+Since Twitter automatically shortens URLs, the team also unshortened every URL in the dataset so that we would be able create a canonical list of URLs tweeted for further analysis. We were able to create this using a combination of tools; [`unshorten.py`](https://github.com/edsu/twarc/blob/master/utils/unshorten.py) and [unshrtn](https://github.com/edsu/unshrtn) ("a small leveldb backed URL unshortening microservice written for node").
 
 ```bash
 $ sudo docker build --tag unshrtn:dev .
@@ -240,7 +240,7 @@ $ python ~/git/twarc/utils/geo.py elxn42-tweets-combined-deduplicated.json > elx
 $ cat elxn42-tweets-with-geo.json | wc -1
 5370
 ```
-We were also able to create a [geoJSON](geojson.org) file of all the tweets with geographic information associated with them. With this geojson file, we were then able to map the tweets fairly simply with [Leaflet.js](http://leafletjs.com).
+We were also able to create a [geoJSON](geojson.org) file of all the tweets with geographic information associated with them. With this geoJSON file, we were then able to map the tweets fairly simply with [Leaflet.js](http://leafletjs.com).
 
 Using `geojson.py` from twarc utilities:
 ```bash
@@ -398,7 +398,7 @@ From the above, we can see that there were 1,988,693 URLs tweeted, representing 
 | 10.  |  2707  | https://www.mypayingads.com/index.php?ref=51826                           |
 
 
-We were also curious how many domains were tweeted. This required two steps. First, taking a text file (see `elxn42-tweets-urls.txt` in our [dataset](http://hdl.handle.net/10864/11311)[6]) of the URL list and then extracting only the domain:
+We were also curious how many domains were tweeted. This required two steps. First, taking a text file (see `elxn42-tweets-urls.txt` in our [dataset](http://hdl.handle.net/10864/11311)) of the URL list and then extracting only the domain:
 
 ```bash
 #!/bin/bash
@@ -479,15 +479,15 @@ From the above, we can see that there were 1,203,867 total images tweets, repres
 
 ### Deleted Tweets
 
-As mentioned above, twarc has a mode called "hydrate". Hydrate allows a user to a take a set of tweet ids -- in this case you can use the data set we are working with here[4] -- and hydrate the tweets ids with the full tweet from the Twitter API. This process can be slow since, "Twitter limits users to 180 API requests every 15 minutes. Each request can hydrate (Twitter’s term for turning a tweet ids into tweet objects at a rate of up to 100 Tweet IDs using the statuses/lookup REST API call. So `80 requests * 100 tweets = 18,000 tweets/15 min = 72,000 tweets/hour`[5]." In our case, we began hydrating on November 21, and finished on November 23. The process took a little over 39 hours. In the end, we had a total of 2,832,270 tweets. Which means that 207,534 tweets deleted, giving us a 7.33% tweet churn.
+As mentioned above, twarc has a mode called "hydrate". Hydrate allows a user to a take a set of tweet ids -- in this case you can use the data set we are working with [here](http://hdl.handle.net/10864/11270) -- and hydrate the tweets ids with the full tweet from the Twitter API. This process can be slow since, "Twitter limits users to 180 API requests every 15 minutes. Each request can hydrate (Twitter’s term for turning a tweet ids into tweet objects) at a rate of up to 100 Tweet IDs using the statuses/lookup REST API call. So `80 requests * 100 tweets = 18,000 tweets/15 min = 72,000 tweets/hour`." (Summers, 2015) In our case, we began hydrating on November 21, and finished on November 23. The process took a little over 39 hours. In the end, we had a total of 2,832,270 tweets. Which means that 207,534 tweets deleted, giving us a 7.33% tweet churn.
 
 The [Twitter Developer Agreement & Policy](https://dev.twitter.com/overview/terms/agreement-and-policy) prevents us from going into much detail on the deleted users, but several significant users were deleted. One, StopHarperToday, no longer exists as of writing. And another major account, 444_nal4b, appears to be a spammer account that extensively tweeted on the #elxn42 hashtag. While Twitter's user experience is arguably enhanced by the loss of spam tweets, they are an essential part of the Twitter experience and it is worth nothing that they may be significantly reduced in rehydrated Twitter databases. Future historians may have difficulty studying the online advertisements – annoying as they can be – of our day, unless the original data is deposited somewhere where it can be studied (the Library of Congress, perhaps?).
 
-But this, as noted in our reflection on ethics, is one of the key components of working responsibly with Twitter. As Ed Summers has put it:
+But this, as noted in our reflection on ethics, is one of the key components of working responsibly with Twitter. As Ed Summers (2015a) has put it:
 
->But if you squint right, Twitter is taking an ethical position for their publishers to be able to remove their data: to exercise their right to be forgotten, allowing them to remove a teensy bit of what Maciej Cegłowski calls informational toxic waste.[16]
+>But if you squint right, Twitter is taking an ethical position for their publishers to be able to remove their data: to exercise their right to be forgotten, allowing them to remove a teensy bit of what Maciej Cegłowski calls informational toxic waste.
 
-People may be deleting their tweets because they were spam, or inflammatory, or something they regretted, especially in the aftermath of a heated election. Summers and Ruest noted much the same with tweets in the aftermath of the Charlie Hebdo massacre.[17] Ultimately, archives are always full of large gaps and omissions: at least in this one we know that people in many cases could make their own informed decision to be removed.
+People may be deleting their tweets because they were spam, or inflammatory, or something they regretted, especially in the aftermath of a heated election. Summers (2015b) and Ruest noted much the same with tweets in the aftermath of the Charlie Hebdo massacre. Ultimately, archives are always full of large gaps and omissions: at least in this one we know that people in many cases could make their own informed decision to be removed.
 
 ## Integrating Twitter Archiving with Web Archiving
 
@@ -517,41 +517,18 @@ We'd like to graciously thank the support of the Social Sciences and Humanities 
 
 ## References
 
-[1]: http://dx.doi.org/10.5281/zenodo.31919 "Ed Summers, Hugo van Kemenade, Peter Binkley, Nick Ruest, recrm, Stefano Costa, Eric Phetteplace, et al. ‘Twarc: v0.3.4.’ Zenodo, 2015. doi:10.5281/zenodo.31919."
-[2]: https://github.com/pbinkley/twarc-report "Peter Binkley. 'twarc-report' GitHub, 2015. https://github.com/pbinkley/twarc-report"
-[3]: https://github.com/edsu/unshrtn "Ed Summers, Daniel Krech. 'unshrtn' GitHub, 2015. https://github.com/edsu/unshrtn"
-[4]: http://hdl.handle.net/10864/11270 "Nick Ruest, '#elxn42 tweets', http://hdl.handle.net/10864/11270 V2 [Version]"
-[5]: https://medium.com/on-archivy/on-forgetting-e01a2b95272 "Ed Summers, 'On Forgetting and hydration', https://medium.com/on-archivy/on-forgetting-e01a2b95272"
-[6]: http://hdl.handle.net/10864/11311 "Nick Ruest, Library and Archives Canada, 2015-12-07, #elxn42 tweets (42nd Canadian Federal Election), http://hdl.handle.net/10864/11311 V1 [Version]"
-[7]: http://hdl.handle.net/10864/11310 "Library and Archives Canada, #elxn42 tweets (42nd Canadian Federal Election), http://hdl.handle.net/10864/11310 V3 [Version]""
-[8]: http://arxiv.org/abs/1212.6177 "Ainsworth, Scott G., Ahmed AlSum, Hany SalahEldeen, Michele C. Weigle, and Michael L. Nelson. “How Much of the Web Is Archived?” arXiv:1212.6177 [cs], December 26, 2012. http://arxiv.org/abs/1212.6177"
-[9]: http://ijoc.org/index.php/ijoc/article/view/2171/1159 "K. Driscoll and S. Walker, “Big Data, Big Questions| Working Within a Black Box: Transparency in the Collection and Production of Big Twitter Data,” International Journal of Communication, vol. 8, no. 0, p. 20, Jun. 2014.""
-[10]: https://dev.twitter.com/rest/public/search "Twitter, 'Search API,' https://dev.twitter.com/rest/public/search"
-[11]: https://dev.twitter.com/streaming/overview "Twitter, 'Streaming API, https://dev.twitter.com/streaming/overview"
-[12]: http://thenewinquiry.com/blogs/zunguzungu/notallpublic-heartburn-twitter/ "A. Bady, #NotAllPublic, Heartburn, Twitter, 10 June 2014, http://thenewinquiry.com/blogs/zunguzungu/notallpublic-heartburn-twitter/, last accessed 16 June 2015"
-[13]: http://www.cbc.ca/newsblogs/yourcommunity/2014/09/universitys-black-twitter-study-generates-controversy.html "Lauren O'Neil, "University's 'Black Twitter' study generates controversy," 4 September 2014, http://www.cbc.ca/newsblogs/yourcommunity/2014/09/universitys-black-twitter-study-generates-controversy.html."
-[14]: https://modelviewculture.com/pieces/the-twitterethics-manifesto "Dorothy Kim and Eunsong Kim, "The #TwitterEthics Manifesto," 7 April 2014, https://modelviewculture.com/pieces/the-twitterethics-manifesto."
-[15]: http://www.lib.umich.edu/webarchivesconference/webarchives-schedule "Seemantani Sharma, Vakil Smallen, and Daniel Chudnov, "Social Feed Manager," presented at *Web Archives 2015: Capture, Curate, Analyze*, Ann Arbor, MI, 13 November 2015."
-[16]: https://medium.com/on-archivy/on-forgetting-e01a2b95272#.84r48yugk "Ed Summers, "On Forgetting and Hydration," 18 November 2014, https://medium.com/on-archivy/on-forgetting-e01a2b95272#.84r48yugk."
-[17]: http://inkdroid.org/2015/04/14/tweets-and-deletes/ "Ed Summers, "Tweets and Deletes," 14 April 2015, http://inkdroid.org/2015/04/14/tweets-and-deletes/."
+* Ainsworth, Scott G., Ahmed AlSum, Hany SalahEldeen, Michele C. Weigle, and Michael L. Nelson. _How Much of the Web Is Archived?_ arXiv:1212.6177 [cs], December 26, 2012. [http://arxiv.org/abs/1212.6177](http://arxiv.org/abs/1212.6177)
+* Bady, A., _#NotAllPublic, Heartburn, Twitter_, 10 June 2014, [http://thenewinquiry.com/blogs/zunguzungu/notallpublic-heartburn-twitter/](http://thenewinquiry.com/blogs/zunguzungu/notallpublic-heartburn-twitter/), last accessed 16 June 2015
+* Driscoll, K. and S. Walker, _Big Data, Big Questions| Working Within a Black Box: Transparency in the Collection and Production of Big Twitter Data_, International Journal of Communication, vol. 8, p. 20, Jun. 2014.
+* Gleick, James, _The Information: A History, a Theory, a Flood_, 2012.
+* Kim, Dorothy and Eunsong Kim, _The #TwitterEthics Manifesto,_ 7 April 2014, [https://modelviewculture.com/pieces/the-twitterethics-manifesto](https://modelviewculture.com/pieces/the-twitterethics-manifesto).
+* O'Neil, Lauren, _University's 'Black Twitter' study generates controversy_, 4 September 2014, [http://www.cbc.ca/newsblogs/yourcommunity/2014/09/universitys-black-twitter-study-generates-controversy.html](http://www.cbc.ca/newsblogs/yourcommunity/2014/09/universitys-black-twitter-study-generates-controversy.html).
+* Ruest, Nick, '#elxn42 tweets', [http://hdl.handle.net/10864/11270](http://hdl.handle.net/10864/11270) V2 [Version], 2015.
+* Sharma, Seemantani; Vakil Smallen; and Daniel Chudnov, "Social Feed Manager," presented at *Web Archives 2015: Capture, Curate, Analyze*, Ann Arbor, MI, 13 November 2015. [http://www.lib.umich.edu/webarchivesconference/webarchives-schedule](http://www.lib.umich.edu/webarchivesconference/webarchives-schedule)
+* Summers, Ed; Hugo van Kemenade; Peter Binkley; Nick Ruest; recrm; Stefano Costa; Eric Phetteplace; et al. _Twarc: v0.3.4._ Zenodo, 2015. [doi:10.5281/zenodo.31919](http://dx.doi.org/10.5281/zenodo.31919).
+* Summers, Ed, _On Forgetting and hydration_, [https://medium.com/on-archivy/on-forgetting-e01a2b95272](https://medium.com/on-archivy/on-forgetting-e01a2b95272), 2015a.
+* Summers, Ed, _Tweets and Deletes_, 14 April 2015, [http://inkdroid.org/2015/04/14/tweets-and-deletes/](http://inkdroid.org/2015/04/14/tweets-and-deletes/), 2015b.
 
-* Ed Summers, Hugo van Kemenade, Peter Binkley, Nick Ruest, recrm, Stefano Costa, Eric Phetteplace, et al. ‘Twarc: v0.3.4.’ Zenodo, 2015. doi:10.5281/zenodo.31919.
-* Peter Binkley. 'twarc-report' GitHub, 2015. https://github.com/pbinkley/twarc-report
-* Ed Summers, Daniel Krech. 'unshrtn' GitHub, 2015. https://github.com/edsu/unshrtn
-* Nick Ruest, '#elxn42 tweets', http://hdl.handle.net/10864/11270 V2 [Version]
-* Ed Summers, 'On Forgetting and hydration', https://medium.com/on-archivy/on-forgetting-e01a2b95272
-* Nick Ruest, Library and Archives Canada, 2015-12-07, #elxn42 tweets (42nd Canadian Federal Election), http://hdl.handle.net/10864/11311 V1 [Version]
-* Library and Archives Canada, #elxn42 tweets (42nd Canadian Federal Election), http://hdl.handle.net/10864/11310 V3 [Version]"
-* Ainsworth, Scott G., Ahmed AlSum, Hany SalahEldeen, Michele C. Weigle, and Michael L. Nelson. "How Much of the Web Is Archived?" arXiv:1212.6177 [cs], December 26, 2012. http://arxiv.org/abs/1212.6177
-* K. Driscoll and S. Walker, "Big Data, Big Questions| Working Within a Black Box: Transparency in the Collection and Production of Big Twitter Data," International Journal of Communication, vol. 8, no. 0, p. 20, Jun. 2014.
-* "Twitter, 'Search API,' https://dev.twitter.com/rest/public/search"
-* "Twitter, 'Streaming API, https://dev.twitter.com/streaming/overview"
-* A. Bady, #NotAllPublic, Heartburn, Twitter, 10 June 2014, http://thenewinquiry.com/blogs/zunguzungu/notallpublic-heartburn-twitter/, last accessed 16 June 2015
-* Lauren O'Neil, "University's 'Black Twitter' study generates controversy," 4 September 2014, http://www.cbc.ca/newsblogs/yourcommunity/2014/09/universitys-black-twitter-study-generates-controversy.html
-* Dorothy Kim and Eunsong Kim, "The #TwitterEthics Manifesto," 7 April 2014, https://modelviewculture.com/pieces/the-twitterethics-manifesto
-* Seemantani Sharma, Vakil Smallen, and Daniel Chudnov, "Social Feed Manager," presented at *Web Archives 2015: Capture, Curate, Analyze*, Ann Arbor, MI, 13 November 2015." http://www.lib.umich.edu/webarchivesconference/webarchives-schedule
-* Ed Summers, "On Forgetting and Hydration," 18 November 2014, https://medium.com/on-archivy/on-forgetting-e01a2b95272#.84r48yugk.
-* Ed Summers, "Tweets and Deletes," 14 April 2015, http://inkdroid.org/2015/04/14/tweets-and-deletes/.
 
 ## About the Authors
 


### PR DESCRIPTION
Looks very good.  Fascinating to read; I had to keep going backwards with an editor's eye as I got engrossed in the content.

This pull request fixes some typos and puts the references into the Code4Lib standard.  The latter messes up the automated processing of your Markdown flavor.  If that is of concern, maybe I can make a separate branch with those changes and apply them myself before copying and pasting the HTML into WordPress.
